### PR TITLE
Initial Commit with Restructured Modules and License

### DIFF
--- a/.README.md
+++ b/.README.md
@@ -1,0 +1,334 @@
+<!-- ---
+!-- title: 2025-01-05 00:06:53
+!-- author: ywata-note-win
+!-- date: /home/ywatanabe/proj/llemacs/.README.md
+!-- --- -->
+
+# Renaming history
+
+./workspace/resources/prompt-templates/components/
+./workspace/projects/000-sample-project/
+
+~/proj/llemacs/workspace/resources/prompt-templates/recipes/
+
+
+## Automatic project development
+
+``` elisp
+;; Initialize a project: setting project-name and goals
+(llemacs--proj-init 
+    "dsp-project" 
+    "Organize a hello world project with unparalleled creativity.")
+    
+(llemacs--proj-collect-context (llemacs--pj-get-cur-pj))
+
+;; Advance the project by LLM agents
+(llemacs--run-prompt
+    (llemacs--proj-collect-context 
+        (llemacs--pj-get-cur-pj)) 
+    "code-gen")
+
+(llemacs--run-prompt "Write a script to show hellow world" "code-gen")
+```
+
+select-safe-coding-system
+
+Select coding system (default raw-text)
+
+(select-safe-coding-system)
+
+/home/ywatanabe/proj/llemacs/workspace/resources/prompts/components/03_rules/proj-structure.md
+
+
+/path/to/llemacs/workspace/projects/`llemacs--cur-pj`/ (= `llemacs--path-pj`)
+├── .env (= `llemacs--path-pj-python-env`)
+│   ├── bin/python (= `llemacs--path-pj-python`)
+├── config (= `llemacs--path-pj-config`)
+├── data (= `llemacs--path-pj-data`)
+├── logs (= `llemacs--path-pj-logs`)
+│   ├── by_level (= `llemacs--path-pj-logs-by-level`)
+│   │   ├── debug.log (Updated using `(llemacs--logging-write-debug-pj message)`)
+│   │   ├── elisp.log (Updated using `(llemacs--logging-write-elisp-pj message)`)
+│   │   ├── error.log (Updated using `(llemacs--logging-write-error-pj message)`)
+│   │   ├── info.log (Updated using `(llemacs--logging-write-info-pj message)`)
+│   │   ├── prompt.log (Updated using `(llemacs--logging-write-prompt-pj message)`)
+│   │   ├── search.log (Updated using `(llemacs--logging-write-search-pj message)`)
+│   │   └── warn.log (Updated using `(llemacs--logging-write-warn-pj message)`)
+│   └── logging.log (Includes all the level-specific logs)
+├── project_management
+│   ├── project_management.gif
+│   ├── project_management.mmd (= `llemacs--path-pj-pm-mmd`)
+│   ├── project_management.png
+│   └── project_management.svg
+├── README.md
+├── requirements.txt
+├── results (= `llemacs--path-pj-results`)
+└── scripts (= `llemacs--path-pj-scripts`)
+
+
+```plaintext
+.
+├── config
+│   ├── README.md
+│   ├── COLORS.yaml
+│   ├── DSP.yaml
+│   ├── ECOG.yaml
+│   ├── GLOBAL.yaml
+│   ├── IS_DEBUG.yaml
+│   ├── ML.yaml
+│   ├── PAC.yaml
+│   ├── PATH.yaml
+│   ├── PATIENTS_ALL.yaml
+│   ├── PATIENTS.yaml
+│   ├── REPRESENTATIVES.yaml
+│   ├── SAMPLING.yaml
+│   └── SEIZURE.yaml
+├── data -> .data/spartan
+│     ├── README.md
+│     ├── db
+│     │   ├── ecog
+│     │   ├── mat
+│     │   ├── meta
+│     │   └── pac
+│     ├── mat
+│     │   └── Annotations
+│     ├── mat_list -> ../../scripts/dataset/list_mat_files
+│     ├── README.md
+│     └── seizures
+│         ├── all.csv -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/all.csv
+│          ├── described.csv -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/described.csv
+│          ├── duration_by_type.csv -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/duration_by_type.csv                        
+│          ├── hourly_dist.jpg -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/hourly_dist.jpg
+│          ├── hours_since_last.jpg -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/hours_since_last.jpg                        
+│          ├── hours_since_last_log.jpg -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/hours_since_last_log.jpg                    
+│          ├── patient_seizures.csv -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/patient_seizures.csv                        
+│          ├── seizure_count.jpg -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/seizure_count.jpg                           
+│          ├── seizure_count_safe.csv -> ../../../scripts/dataset/inspect_seizure_annotations/seizure_count_safe.csv
+│          ├── seizure_duration_hist.jpg -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/seizure_duration_hist.jpg                   
+│          ├── seizure_raster.jpg -> ../../../scripts/dataset/inspect_seizure_annotations/data/seizures/seizure_raster.jpg                          
+├── docs
+│   ├── dataset.md
+│   ├── installation.md
+│   └── memo.md
+├── models
+│   ├── best_model_23_004.pt
+│   └── hub
+├── paper
+│   ├── compile -> scripts/compile-all.sh
+│   ├── compile.log
+│   ├── data
+│   ├── manuscript
+│   ├── README.md
+│   ├── revision
+│   ├── scripts
+│   └── supplementary
+├── README.md
+└── scripts
+    ├── dataset
+    │   ├── check_disk_usage_and_du.log
+    │   ├── check_disk_usage_and_du.sh
+    │   ├── check_number_of_mat_files.sh
+    │   ├── check_number_of_mat_files.sh.log
+    │   ├── check_number_of_mat_files.sh.logs
+    │   ├── create_mat_files_list
+    │   ├── define_control_seizures.py
+    │   ├── demographic_data.py
+    │   ├── extract_patient_directories.sh
+    │   ├── inspect_annotations
+    │   ├── inspect_dropout.py
+    │   ├── inspect_intertimes.py
+    │   ├── _inspect_metadata.py
+    │   ├── inspect_seizure_annotations
+    │   ├── inspect_seizure_annotations.py
+    │   ├── list_mat_files
+    │   ├── list_mat_files.sh
+    │   ├── list_multiple_tar_files.log
+    │   ├── list_multiple_tar_files.sh
+    │   ├── list_n_mat_files.sh
+    │   ├── list_tar_file.log
+    │   ├── list_tar_file.sh
+    │   ├── README.md
+    │   ├── remove_mat_files.sh
+    │   ├── rsync_from_punim2354_to_punim0264.log
+    │   ├── rsync_from_punim2354_to_punim0264.sh
+    │   ├── rsync_from_punim2354_to_punim0264.sh%.log
+    │   ├── tar_and_notify.log
+    │   ├── tar_and_notify.sh
+    │   ├── tar_each_dir.sh
+    │   ├── tar_patients.sh
+    │   ├── tar_patients.sh.tar-process.log
+    │   └── titan.md
+    ├── db
+    │   ├── check_db_sizes.sh
+    │   ├── check_duplicates.log
+    │   ├── combine_all_dbs.py
+    │   ├── delete_duplicates
+    │   ├── delete_duplicates.log
+    │   ├── extract_timetable
+    │   ├── extract_timetable.py
+    │   ├── extract_timetables.sh
+    │   ├── fixing_scripts
+    │   ├── init_as_unverified.log
+    │   ├── inspect_dbs
+    │   ├── inspect_dbs.log
+    │   ├── inspect_mat_file_format.py
+    │   ├── load_db_test
+    │   ├── ls_db
+    │   ├── MigrateDB.py
+    │   ├── NeuroVistaDBEEGPopulate.py
+    │   ├── NeuroVistaDBEEG.py
+    │   ├── NeuroVistaDBPACPopulate.py
+    │   ├── NeuroVistaDBPAC.py
+    │   ├── NeuroVistaDB.py
+    │   ├── old
+    │   ├── populate_db
+    │   ├── populate_db.log
+    │   ├── populate_db.py
+    │   ├── populate_db.sh
+    │   ├── populate_dbs.log
+    │   ├── populate_dbs.sh
+    │   ├── populate_meta_db
+    │   ├── populate_meta_db.log
+    │   ├── populate_meta_db.py
+    │   ├── populate_meta_dbs.log
+    │   ├── populate_meta_dbs.sh
+    │   ├── populate_meta_modules
+    │   ├── rsync_dbs_from_titan_to_spartan.sh
+    │   ├── softlink_dbs.sh
+    │   ├── stop_populating.sh
+    │   ├── summarize
+    │   ├── summarize_all
+    │   ├── symlink_dbs.sh
+    │   ├── verify_db
+    │   └── verify_db.py
+    ├── eda
+    │   ├── check_interictal_control
+    │   ├── check_interictal_control.py
+    │   ├── covariance_matrix
+    │   ├── covariance_matrix.py
+    │   ├── covariance_matrix.sh
+    │   ├── covariance_matrix.sh.log
+    │   ├── demographic_data
+    │   ├── _for_seerpy_data
+    │   ├── __init__.py
+    │   ├── inspect_annotations
+    │   ├── inspect_dropout
+    │   ├── inter_seizure_interval
+    │   ├── inter_seizure_interval.py
+    │   ├── plot_covariance_matrix.py
+    │   ├── plot_covariance_matrix.sh
+    │   ├── plot_covariance_matrix.sh.log
+    │   ├── plot_seizure_aligned_signals
+    │   ├── plot_seizure_aligned_signals.log
+    │   ├── plot_seizure_aligned_signals.py
+    │   ├── plot_seizure_aligned_signals.sh
+    │   ├── plot_seizure_aligned_signals.sh.log
+    │   ├── plot_seizure_aligned_signals_working.py
+    │   ├── plot_seizure_raster
+    │   └── plot_seizure_raster.py
+    ├── __init__.py
+    ├── io
+    │   └── load_db
+    ├── ml
+    │   ├── catboost
+    │   ├── clf
+    │   ├── clf_catboost
+    │   ├── clf_catboost_on_descriptive_stats
+    │   ├── clf_catboost_on_descriptive_stats.py
+    │   ├── clf_catboost_on_descriptive_stats.sh
+    │   ├── clf_catboost_on_vit_extracted_features
+    │   ├── clf_catboost_on_vit_extracted_features.py
+    │   ├── clf_catboost_on_vit_extracted_features_sbatch.py
+    │   ├── clf_catboost_on_vit_extracted_features_sbatch.sh
+    │   ├── clf_catboost_on_vit_extracted_features_timeseries_CV
+    │   ├── clf_catboost_on_vit_extracted_features_timeseries_CV.py
+    │   ├── clf_catboost_on_vit_extracted_features_timeseries_CV_sbatch.sh
+    │   ├── clf_catboost_on_x_cat_results.sh
+    │   ├── clf_catboost_on_x_cat_results.sh.csv
+    │   ├── clf_vit
+    │   ├── clf_vit.py
+    │   ├── clf_vit_seerpy_working.py
+    │   ├── _for_seerpy_data
+    │   ├── helpers
+    │   ├── __init__.py
+    │   ├── __pycache__
+    │   ├── reg_catboost_on_descriptive_stats
+    │   ├── reg_catboost_on_descriptive_stats.py
+    │   ├── summarize_clf_results.sh
+    │   ├── summarize_clf_results.sh.txt
+    │   ├── visualize_pac_and_vit_attentions
+    │   └── visualize_pac_and_vit_attentions.py
+    ├── pac
+    │   ├── _arr2vit_frts_sbatch.sh
+    │   ├── arr2vit_frts_sbatch.sh
+    │   ├── arr2vit_ftrs
+    │   ├── arr2vit_ftrs.py
+    │   ├── arr2vit_ftrs_sbatch_long.sh
+    │   ├── arr2vit_ftrs_sbatch.sh
+    │   ├── _calc_pac
+    │   ├── calc_pac
+    │   ├── calc_pac_around_seizures
+    │   ├── calc_pac_around_seizures 
+    │   ├── calc_pac_around_seizures.py
+    │   ├── calc_pac_around_seizures_sbatch_long.sh
+    │   ├── calc_pac_around_seizures_sbatch_long.sh.logs
+    │   ├── calc_pac_around_seizures_sbatch.sh
+    │   ├── calc_pac_around_seizures_sbatch.sh.logs
+    │   ├── _calc_pac.py
+    │   ├── _calc_pac_sbatch.logs
+    │   ├── calc_pac_sbatch_long.sh
+    │   ├── calc_pac_sbatch_long.sh.logs
+    │   ├── calc_pac_sbatch.sh
+    │   ├── calc_pac_sbatch.sh.logs
+    │   ├── count_n_seiizures_in_pac_db
+    │   ├── count_n_seiizures_in_pac_db.py
+    │   ├── count_n_seizures_in_pac_db
+    │   ├── count_n_seizures_in_pac_db.py
+    │   ├── db2arr
+    │   ├── db2arr.py
+    │   ├── describe
+    │   ├── describe.py
+    │   ├── im2vid_pac_optical_flow.sh
+    │   ├── im2vid_pac.sh
+    │   ├── plot_descriptive_stats
+    │   ├── plot_descriptive_stats.py
+    │   ├── pre_seizure_pac_descriptive_statistic_values
+    │   ├── pre_seizure_pac_descriptive_statistic_values.py
+    │   ├── pre_seizure_pac_descriptive_statistic_values.sh
+    │   ├── pre_seizure_pac_descriptive_statistic_values.sh.logs
+    │   ├── scale_check.py
+    │   ├── visualize_pac
+    │   ├── visualize_pac_optical_flow
+    │   ├── visualize_pac_optical_flow.py
+    │   ├── visualize_pac_optical_flow_sbatch.sh
+    │   ├── visualize_pac_optical_flow_sbatch_.sh
+    │   ├── visualize_pac.py
+    │   ├── visualize_pac_sbatch.logs
+    │   ├── visualize_pac_sbatch.sh
+    │   └── visualize_pac_sbatch.sh.logs
+    ├── postgres
+    │   ├── examples
+    │   ├── README.md
+    │   ├── schema
+    │   ├── setup
+    │   ├── setup.sh
+    │   └── setup.sh.log
+    ├── utils
+    │   ├── _add_eeg_dtype_and_shape.py
+    │   ├── im2vid.sh
+    │   ├── __init__.py
+    │   ├── list_figures.sh -> .list_figures-versions/list_figures_v001.sh
+    │   ├── _load_eeg_around_seizures.py
+    │   ├── _load_pac
+    │   ├── _load_pac_all
+    │   ├── _load_pac_all.py -> ._load_pac_all-versions/_load_pac_all_v001.py
+    │   ├── _load_pac.py
+    │   ├── _load_seizure_aligned_eeg
+    │   ├── _load_seizure_aligned_eeg.py -> ._load_seizure_aligned_eeg-versions/_load_seizure_aligned_eeg_v001.py
+    │   ├── merge_figures_pac_amp.py
+    │   ├── _parse_lpath_mat.py
+    │   ├── __pycache__
+    │   └── _rm_figures.sh
+    └── vit
+        └── pac2vitfeatures.py
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,217 @@
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+The GNU General Public License is a free, copyleft license for software and other kinds of works.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+
+Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS
+0. Definitions.
+“This License” refers to version 3 of the GNU General Public License.
+
+“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations.
+
+To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work.
+
+A “covered work” means either the unmodified Program or a work based on the Program.
+
+To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work.
+
+A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”.
+c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+
+An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's “contributor version”.
+
+A contributor's “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Use with the GNU Affero General Public License.
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+
+14. Revised Versions of this License.
+The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an “about box”.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.

--- a/docs/add_copyright_headers.sh
+++ b/docs/add_copyright_headers.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Add GPL-3.0 headers to all .el files
+find . -type f -name "*.el" -exec sh -c '
+  if ! grep -q "Copyright (C)" "$1"; then
+    temp=$(mktemp)
+    echo ";; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)" > "$temp"
+    echo ";;" >> "$temp"
+    echo ";; This program is free software: you can redistribute it and/or modify" >> "$temp"
+    echo ";; it under the terms of the GNU General Public License as published by" >> "$temp" 
+    echo ";; the Free Software Foundation, either version 3 of the License, or" >> "$temp"
+    echo ";; (at your option) any later version." >> "$temp"
+    echo ";;" >> "$temp"
+    cat "$1" >> "$temp"
+    mv "$temp" "$1"
+  fi
+' sh {} \;

--- a/docs/dev/todo.md
+++ b/docs/dev/todo.md
@@ -1,0 +1,26 @@
+<!-- ---
+!-- title: 2025-01-04 21:49:56
+!-- author: ywata-note-win
+!-- date: /home/ywatanabe/proj/llemacs/docs/dev/todo.md
+!-- --- -->
+
+
+- [ ] Planner
+  - [ ] small pieces of tasks
+  - [ ] breaking down
+
+- [ ] Caller info
+- [ ] Log level threshold max retry
+- [ ] Context updater specific to directory structure…
+- [ ] Git
+- [ ] GitHub
+- [ ] path is project route
+- [ ] Cat, rg
+- [ ] Prompt manual check
+- [ ] Evaluator
+- [ ] Smaller tasks
+- [ ] Modular approach
+- [ ] Context organizer
+- [ ] Concrete rules
+- [ ] Concrete examples
+- [ ] Log truncation

--- a/llemacs.el/.old/00-elmo-deps.el
+++ b/llemacs.el/.old/00-elmo-deps.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-24 23:14:28
 ;;; Time-stamp: <2024-12-24 23:14:28 (ywatanabe)>

--- a/llemacs.el/.old/02-llemacs-logging-db.el
+++ b/llemacs.el/.old/02-llemacs-logging-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 12:16:16
 ;;; Time-stamp: <2024-12-31 12:16:16 (ywatanabe)>

--- a/llemacs.el/.old/02-llemacs-logging-mainteners.el
+++ b/llemacs.el/.old/02-llemacs-logging-mainteners.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:58:23
 ;;; Time-stamp: <2024-12-31 16:58:23 (ywatanabe)>

--- a/llemacs.el/.old/02-llemacs-logging-structures.el
+++ b/llemacs.el/.old/02-llemacs-logging-structures.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 11:35:24
 ;;; Time-stamp: <2024-12-31 11:35:24 (ywatanabe)>

--- a/llemacs.el/.old/05-elmo-image.el
+++ b/llemacs.el/.old/05-elmo-image.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-24 18:02:38
 ;;; Time-stamp: <2024-12-24 18:02:38 (ywatanabe)>

--- a/llemacs.el/.old/09-elmo-lang2elisp_.el
+++ b/llemacs.el/.old/09-elmo-lang2elisp_.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-27 19:36:26
 ;;; Time-stamp: <2024-12-27 19:36:26 (ywatanabe)>

--- a/llemacs.el/.old/_02-llemacs-logging-get.el
+++ b/llemacs.el/.old/_02-llemacs-logging-get.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:22:15
 ;;; Time-stamp: <2024-12-31 16:22:15 (ywatanabe)>

--- a/llemacs.el/.old/_02-llemacs-logging-loggers.el
+++ b/llemacs.el/.old/_02-llemacs-logging-loggers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:49:27
 ;;; Time-stamp: <2024-12-31 16:49:27 (ywatanabe)>

--- a/llemacs.el/.old/_02-llemacs-logging-view.el
+++ b/llemacs.el/.old/_02-llemacs-logging-view.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:54:13
 ;;; Time-stamp: <2024-12-31 16:54:13 (ywatanabe)>

--- a/llemacs.el/.old/_02-llemacs-logging-view__.el
+++ b/llemacs.el/.old/_02-llemacs-logging-view__.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:54:13
 ;;; Time-stamp: <2024-12-31 16:54:13 (ywatanabe)>

--- a/llemacs.el/.old/_02-llemacs-logging_.el
+++ b/llemacs.el/.old/_02-llemacs-logging_.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:48:00
 ;;; Time-stamp: <2024-12-31 16:48:00 (ywatanabe)>

--- a/llemacs.el/.old/_02-llemacs-utils-logging.el
+++ b/llemacs.el/.old/_02-llemacs-utils-logging.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 12:07:27
 ;;; Time-stamp: <2024-12-31 12:07:27 (ywatanabe)>

--- a/llemacs.el/.old/_03-llemacs-llm_v01.el
+++ b/llemacs.el/.old/_03-llemacs-llm_v01.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 11:42:17
 ;;; Time-stamp: <2024-12-31 11:42:17 (ywatanabe)>

--- a/llemacs.el/.old/_04-llemacs/run/_06-llemacs-run.el
+++ b/llemacs.el/.old/_04-llemacs/run/_06-llemacs-run.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:22:17
 ;;; Time-stamp: <2024-12-31 16:22:17 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-mode.el
+++ b/llemacs.el/.old/_elmo-mode.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-02 10:56:41
 ;;; Time-stamp: <2024-12-02 10:56:41 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-network.el
+++ b/llemacs.el/.old/_elmo-network.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-03 16:42:33
 ;;; Time-stamp: <2024-12-03 16:42:33 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-python.el
+++ b/llemacs.el/.old/_elmo-python.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-06 00:32:35
 ;;; Time-stamp: <2024-12-06 00:32:35 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-self-evolve.el
+++ b/llemacs.el/.old/_elmo-self-evolve.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-04 08:56:43
 ;;; Time-stamp: <2024-12-04 08:56:43 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-server.el
+++ b/llemacs.el/.old/_elmo-server.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-06 04:34:52
 ;;; Time-stamp: <2024-12-06 04:34:52 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-sudo.el
+++ b/llemacs.el/.old/_elmo-sudo.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-06 05:20:39
 ;;; Time-stamp: <2024-12-06 05:20:39 (ywatanabe)>

--- a/llemacs.el/.old/_elmo-version-control.el
+++ b/llemacs.el/.old/_elmo-version-control.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-04 08:58:01
 ;;; Time-stamp: <2024-12-04 08:58:01 (ywatanabe)>

--- a/llemacs.el/.old/_llemacs-logging-db.el
+++ b/llemacs.el/.old/_llemacs-logging-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-30 23:13:41
 ;;; Time-stamp: <2024-12-30 23:13:41 (ywatanabe)>

--- a/llemacs.el/.old/elmo-install.el
+++ b/llemacs.el/.old/elmo-install.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-06 01:23:22
 ;;; Time-stamp: <2024-12-06 01:23:22 (ywatanabe)>

--- a/llemacs.el/.old/elmo-verify-installation.el
+++ b/llemacs.el/.old/elmo-verify-installation.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-02 06:44:15
 ;;; Time-stamp: <2024-12-02 06:44:15 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/003-01-buf-var-pj.el
+++ b/llemacs.el/01-llemacs-base/.old/003-01-buf-var-pj.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 20:32:31
 ;;; Time-stamp: <2025-01-03 20:32:31 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/01-llemacs-base-buffers.el
+++ b/llemacs.el/01-llemacs-base/.old/01-llemacs-base-buffers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 23:06:07
 ;;; Time-stamp: <2024-12-31 23:06:07 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/100-paths.el
+++ b/llemacs.el/01-llemacs-base/.old/100-paths.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 09:54:55
 ;;; Time-stamp: <2025-01-04 09:54:55 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/101-paths-logging-global.el
+++ b/llemacs.el/01-llemacs-base/.old/101-paths-logging-global.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 22:32:26
 ;;; Time-stamp: <2025-01-03 22:32:26 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/102-paths-resources.el
+++ b/llemacs.el/01-llemacs-base/.old/102-paths-resources.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 18:54:48
 ;;; Time-stamp: <2025-01-03 18:54:48 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/103-paths-python.el
+++ b/llemacs.el/01-llemacs-base/.old/103-paths-python.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 22:38:03
 ;;; Time-stamp: <2025-01-03 22:38:03 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/300-paths-prompt.el
+++ b/llemacs.el/01-llemacs-base/.old/300-paths-prompt.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 18:55:04
 ;;; Time-stamp: <2025-01-03 18:55:04 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/900-paths-project.el
+++ b/llemacs.el/01-llemacs-base/.old/900-paths-project.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 22:41:06
 ;;; Time-stamp: <2025-01-03 22:41:06 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/901-paths-logging-project.el
+++ b/llemacs.el/01-llemacs-base/.old/901-paths-logging-project.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 18:54:06
 ;;; Time-stamp: <2025-01-03 18:54:06 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/_001-2nd-groups.el
+++ b/llemacs.el/01-llemacs-base/.old/_001-2nd-groups.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 19:49:21
 ;;; Time-stamp: <2025-01-03 20:02:30 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/.old/paths.el
+++ b/llemacs.el/01-llemacs-base/.old/paths.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 14:04:42
 ;;; Time-stamp: <2025-01-03 14:07:54 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/000-entry.el
+++ b/llemacs.el/01-llemacs-base/000-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:48:28
 ;;; Time-stamp: <2025-01-04 14:48:28 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/000-list.el
+++ b/llemacs.el/01-llemacs-base/000-list.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:41:10
 ;;; Time-stamp: <2025-01-04 14:41:10 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/001-groups.el
+++ b/llemacs.el/01-llemacs-base/001-groups.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 22:59:47
 ;;; Time-stamp: <2025-01-03 22:59:47 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/010-buf-var.el
+++ b/llemacs.el/01-llemacs-base/010-buf-var.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:49:29
 ;;; Time-stamp: <2025-01-04 14:49:29 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/011-buf-func.el
+++ b/llemacs.el/01-llemacs-base/011-buf-func.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 18:12:33
 ;;; Time-stamp: <2025-01-04 18:12:33 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/100-paths-sys-log.el
+++ b/llemacs.el/01-llemacs-base/100-paths-sys-log.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 10:44:17
 ;;; Time-stamp: <2025-01-04 10:44:17 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/100-paths-sys.el
+++ b/llemacs.el/01-llemacs-base/100-paths-sys.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 10:44:21
 ;;; Time-stamp: <2025-01-04 10:44:21 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/101-paths-pj-log.el
+++ b/llemacs.el/01-llemacs-base/101-paths-pj-log.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 16:34:23
 ;;; Time-stamp: <2025-01-04 16:34:23 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/101-paths-pj.el
+++ b/llemacs.el/01-llemacs-base/101-paths-pj.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-05 00:38:12
 ;;; Time-stamp: <2025-01-05 00:38:12 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/102-paths-pj-lock-system.el
+++ b/llemacs.el/01-llemacs-base/102-paths-pj-lock-system.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:13:47
 ;;; Time-stamp: <2025-01-04 14:13:47 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/103-paths-pj-handlers.el
+++ b/llemacs.el/01-llemacs-base/103-paths-pj-handlers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 22:09:59
 ;;; Time-stamp: <2025-01-04 22:09:59 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/999-debug.el
+++ b/llemacs.el/01-llemacs-base/999-debug.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 20:57:11
 ;;; Time-stamp: <2025-01-03 20:57:11 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/999-md-json-loaders.el
+++ b/llemacs.el/01-llemacs-base/999-md-json-loaders.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 15:54:34
 ;;; Time-stamp: <2025-01-04 15:54:34 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/999-timestamp.el
+++ b/llemacs.el/01-llemacs-base/999-timestamp.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 20:56:45
 ;;; Time-stamp: <2025-01-03 20:56:45 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test-llemacs-base.el
+++ b/llemacs.el/01-llemacs-base/test/test-llemacs-base.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:24:18
 ;;; Time-stamp: <2025-01-04 14:24:18 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test-llemacs-buffers.el
+++ b/llemacs.el/01-llemacs-base/test/test-llemacs-buffers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:24:31
 ;;; Time-stamp: <2025-01-04 14:24:31 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test-llemacs-loaders.el
+++ b/llemacs.el/01-llemacs-base/test/test-llemacs-loaders.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:24:55
 ;;; Time-stamp: <2025-01-04 14:24:55 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test-llemacs-locks.el
+++ b/llemacs.el/01-llemacs-base/test/test-llemacs-locks.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:23:39
 ;;; Time-stamp: <2025-01-04 14:23:39 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test-llemacs-logging.el
+++ b/llemacs.el/01-llemacs-base/test/test-llemacs-logging.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 22:08:56
 ;;; Time-stamp: <2025-01-04 22:08:56 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test-llemacs-paths.el
+++ b/llemacs.el/01-llemacs-base/test/test-llemacs-paths.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:43:20
 ;;; Time-stamp: <2025-01-04 14:43:20 (ywatanabe)>

--- a/llemacs.el/01-llemacs-base/test/test.el
+++ b/llemacs.el/01-llemacs-base/test/test.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:42:03
 ;;; Time-stamp: <2025-01-04 14:42:03 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/_db-getters.el
+++ b/llemacs.el/02-llemacs-logging/.old/_db-getters.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:54:59
 ;;; Time-stamp: <2025-01-02 10:54:59 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/_db-initializers.el
+++ b/llemacs.el/02-llemacs-logging/.old/_db-initializers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 00:40:39
 ;;; Time-stamp: <2025-01-03 00:40:39 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/_db-loggers.el
+++ b/llemacs.el/02-llemacs-logging/.old/_db-loggers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:55:07
 ;;; Time-stamp: <2025-01-02 10:55:07 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/_db-maintainers.el
+++ b/llemacs.el/02-llemacs-logging/.old/_db-maintainers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:55:13
 ;;; Time-stamp: <2025-01-02 10:55:13 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/_db-variables.el
+++ b/llemacs.el/02-llemacs-logging/.old/_db-variables.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 02:57:58
 ;;; Time-stamp: <2025-01-02 02:57:58 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/_db-viewers.el
+++ b/llemacs.el/02-llemacs-logging/.old/_db-viewers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:54:56
 ;;; Time-stamp: <2025-01-02 10:54:56 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/core-utils.el
+++ b/llemacs.el/02-llemacs-logging/.old/core-utils.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-01 05:50:48
 ;;; Time-stamp: <2025-01-01 05:50:48 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/initializers.el
+++ b/llemacs.el/02-llemacs-logging/.old/initializers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:48:28
 ;;; Time-stamp: <2025-01-04 12:48:28 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-getters-db.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-getters-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:57:24
 ;;; Time-stamp: <2024-12-31 16:57:24 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-getters-file.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-getters-file.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:57:30
 ;;; Time-stamp: <2024-12-31 16:57:30 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-initializers-db.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-initializers-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:58:11
 ;;; Time-stamp: <2024-12-31 16:58:11 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-initializers-file.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-initializers-file.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:59:36
 ;;; Time-stamp: <2024-12-31 16:59:36 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-loggers-db.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-loggers-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:51:09
 ;;; Time-stamp: <2024-12-31 16:51:09 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-loggers-file.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-loggers-file.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:52:01
 ;;; Time-stamp: <2024-12-31 16:52:01 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-maintainers-db.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-maintainers-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 17:01:03
 ;;; Time-stamp: <2024-12-31 17:01:03 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-maintainers-file.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-maintainers-file.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 17:01:12
 ;;; Time-stamp: <2024-12-31 17:01:12 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-viewers-db.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-viewers-db.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:56:05
 ;;; Time-stamp: <2024-12-31 16:56:05 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-viewers-file.el
+++ b/llemacs.el/02-llemacs-logging/.old/not_organized_yet/02-llemacs-logging-viewers-file.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 16:56:14
 ;;; Time-stamp: <2024-12-31 16:56:14 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/00-entry.el
+++ b/llemacs.el/02-llemacs-logging/00-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:52:08
 ;;; Time-stamp: <2025-01-04 12:52:08 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/getters.el
+++ b/llemacs.el/02-llemacs-logging/getters.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:33:50
 ;;; Time-stamp: <2025-01-04 12:33:50 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/level.el
+++ b/llemacs.el/02-llemacs-logging/level.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 21:53:57
 ;;; Time-stamp: <2025-01-04 21:53:57 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/loggers.el
+++ b/llemacs.el/02-llemacs-logging/loggers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-05 00:15:07
 ;;; Time-stamp: <2025-01-05 00:15:07 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/loggers_.el
+++ b/llemacs.el/02-llemacs-logging/loggers_.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-05 00:10:28
 ;;; Time-stamp: <2025-01-05 00:10:28 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/maintainers.el
+++ b/llemacs.el/02-llemacs-logging/maintainers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:49:37
 ;;; Time-stamp: <2025-01-04 12:49:37 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/refreshers.el
+++ b/llemacs.el/02-llemacs-logging/refreshers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 09:42:08
 ;;; Time-stamp: <2025-01-04 09:42:08 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/test/test-llemacs-logging-getters.el
+++ b/llemacs.el/02-llemacs-logging/test/test-llemacs-logging-getters.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:39:15
 ;;; Time-stamp: <2025-01-04 12:39:15 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/test/test-llemacs-logging.el
+++ b/llemacs.el/02-llemacs-logging/test/test-llemacs-logging.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 16:03:21
 ;;; Time-stamp: <2025-01-04 16:03:21 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/test/test.el
+++ b/llemacs.el/02-llemacs-logging/test/test.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 13:09:52
 ;;; Time-stamp: <2025-01-04 13:09:52 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/variables.el
+++ b/llemacs.el/02-llemacs-logging/variables.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 09:31:25
 ;;; Time-stamp: <2025-01-04 09:31:25 (ywatanabe)>

--- a/llemacs.el/02-llemacs-logging/viewers.el
+++ b/llemacs.el/02-llemacs-logging/viewers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:50:57
 ;;; Time-stamp: <2025-01-04 12:50:57 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/.old/_context-xxx.el
+++ b/llemacs.el/03-llemacs-llm/.old/_context-xxx.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:54:04
 ;;; Time-stamp: <2025-01-02 10:54:04 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/.old/prompt-recipes/code-gen.el
+++ b/llemacs.el/03-llemacs-llm/.old/prompt-recipes/code-gen.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 13:58:17
 ;;; Time-stamp: <2025-01-03 13:58:17 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/.old/prompt-recipes/main.el
+++ b/llemacs.el/03-llemacs-llm/.old/prompt-recipes/main.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 12:59:43
 ;;; Time-stamp: <2025-01-03 12:59:43 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/.old/prompt-recipes/nil.el
+++ b/llemacs.el/03-llemacs-llm/.old/prompt-recipes/nil.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 12:59:10
 ;;; Time-stamp: <2025-01-03 12:59:10 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/.old/prompt-recipes/report-gen.el
+++ b/llemacs.el/03-llemacs-llm/.old/prompt-recipes/report-gen.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 12:59:01
 ;;; Time-stamp: <2025-01-03 12:59:01 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/.old/prompt/.old/recipes.el
+++ b/llemacs.el/03-llemacs-llm/.old/prompt/.old/recipes.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2024-12-31 22:57:12
 ;;; Time-stamp: <2024-12-31 22:57:12 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/00-entry.el
+++ b/llemacs.el/03-llemacs-llm/00-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-01 22:53:16
 ;;; Time-stamp: <2025-01-01 22:53:16 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/core-api-keys-and-engines.el
+++ b/llemacs.el/03-llemacs-llm/core-api-keys-and-engines.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 12:53:14
 ;;; Time-stamp: <2025-01-04 12:53:14 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/core-call-providers.el
+++ b/llemacs.el/03-llemacs-llm/core-call-providers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 04:02:09
 ;;; Time-stamp: <2025-01-03 04:02:09 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/core-call-wrapper.el
+++ b/llemacs.el/03-llemacs-llm/core-call-wrapper.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 23:15:02
 ;;; Time-stamp: <2025-01-04 23:15:02 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/core-configs.el
+++ b/llemacs.el/03-llemacs-llm/core-configs.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-01 22:51:16
 ;;; Time-stamp: <2025-01-01 22:51:16 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/core-helpers.el
+++ b/llemacs.el/03-llemacs-llm/core-helpers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 16:36:38
 ;;; Time-stamp: <2025-01-04 16:36:38 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/prompt-compile.el
+++ b/llemacs.el/03-llemacs-llm/prompt-compile.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-05 01:09:08
 ;;; Time-stamp: <2025-01-05 01:09:08 (ywatanabe)>

--- a/llemacs.el/03-llemacs-llm/prompt-recipes.el
+++ b/llemacs.el/03-llemacs-llm/prompt-recipes.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 13:58:10
 ;;; Time-stamp: <2025-01-03 13:58:10 (ywatanabe)>

--- a/llemacs.el/04-llemacs-cvt/00-entry.el
+++ b/llemacs.el/04-llemacs-cvt/00-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:54:42
 ;;; Time-stamp: <2025-01-02 10:54:42 (ywatanabe)>

--- a/llemacs.el/04-llemacs-cvt/lang2elisp.el
+++ b/llemacs.el/04-llemacs-cvt/lang2elisp.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 23:14:08
 ;;; Time-stamp: <2025-01-04 23:14:08 (ywatanabe)>

--- a/llemacs.el/04-llemacs-cvt/mdjson.el
+++ b/llemacs.el/04-llemacs-cvt/mdjson.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 15:41:03
 ;;; Time-stamp: <2025-01-04 15:41:03 (ywatanabe)>

--- a/llemacs.el/04-llemacs-cvt/t2t-compress.el
+++ b/llemacs.el/04-llemacs-cvt/t2t-compress.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-01 14:37:14
 ;;; Time-stamp: <2025-01-01 14:37:14 (ywatanabe)>

--- a/llemacs.el/04-llemacs-cvt/test/test_mdjson.el
+++ b/llemacs.el/04-llemacs-cvt/test/test_mdjson.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 14:36:42
 ;;; Time-stamp: <2025-01-04 14:36:42 (ywatanabe)>

--- a/llemacs.el/05-llemacs-run/.old/05-llemacs-run_.el
+++ b/llemacs.el/05-llemacs-run/.old/05-llemacs-run_.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-01 04:50:22
 ;;; Time-stamp: <2025-01-01 04:50:22 (ywatanabe)>

--- a/llemacs.el/05-llemacs-run/.old/helpers.el
+++ b/llemacs.el/05-llemacs-run/.old/helpers.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 03:21:52
 ;;; Time-stamp: <2025-01-02 03:21:52 (ywatanabe)>

--- a/llemacs.el/05-llemacs-run/00-entry.el
+++ b/llemacs.el/05-llemacs-run/00-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 23:16:00
 ;;; Time-stamp: <2025-01-04 23:16:00 (ywatanabe)>

--- a/llemacs.el/05-llemacs-run/run-elisp.el
+++ b/llemacs.el/05-llemacs-run/run-elisp.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:24:02
 ;;; Time-stamp: <2025-01-02 10:24:02 (ywatanabe)>

--- a/llemacs.el/05-llemacs-run/run-prompt.el
+++ b/llemacs.el/05-llemacs-run/run-prompt.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 23:21:47
 ;;; Time-stamp: <2025-01-04 23:21:47 (ywatanabe)>

--- a/llemacs.el/06-llemacs-proj/.old/step.el
+++ b/llemacs.el/06-llemacs-proj/.old/step.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:55:19
 ;;; Time-stamp: <2025-01-02 10:55:19 (ywatanabe)>

--- a/llemacs.el/06-llemacs-proj/00-entry.el
+++ b/llemacs.el/06-llemacs-proj/00-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 04:28:48
 ;;; Time-stamp: <2025-01-03 04:28:48 (ywatanabe)>

--- a/llemacs.el/06-llemacs-proj/proj-collect-context.el
+++ b/llemacs.el/06-llemacs-proj/proj-collect-context.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-05 01:29:18
 ;;; Time-stamp: <2025-01-05 01:29:18 (ywatanabe)>

--- a/llemacs.el/06-llemacs-proj/proj-init.el
+++ b/llemacs.el/06-llemacs-proj/proj-init.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 22:08:15
 ;;; Time-stamp: <2025-01-04 22:08:15 (ywatanabe)>

--- a/llemacs.el/06-llemacs-proj/proj-lock.el
+++ b/llemacs.el/06-llemacs-proj/proj-lock.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 10:34:25
 ;;; Time-stamp: <2025-01-04 10:34:25 (ywatanabe)>

--- a/llemacs.el/06-llemacs-proj/proj-variables.el
+++ b/llemacs.el/06-llemacs-proj/proj-variables.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 02:11:11
 ;;; Time-stamp: <2025-01-03 02:11:11 (ywatanabe)>

--- a/llemacs.el/07-llemacs-tools/_99-llemacs-search.el
+++ b/llemacs.el/07-llemacs-tools/_99-llemacs-search.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 10:54:48
 ;;; Time-stamp: <2025-01-02 10:54:48 (ywatanabe)>

--- a/llemacs.el/08-llemacs-git/00-entry.el
+++ b/llemacs.el/08-llemacs-git/00-entry.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 11:59:23
 ;;; Time-stamp: <2025-01-02 11:59:23 (ywatanabe)>

--- a/llemacs.el/08-llemacs-git/main.el
+++ b/llemacs.el/08-llemacs-git/main.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-02 12:07:55
 ;;; Time-stamp: <2025-01-02 12:07:55 (ywatanabe)>

--- a/llemacs.el/08-llemacs-git/test/test-llemacs-git.el
+++ b/llemacs.el/08-llemacs-git/test/test-llemacs-git.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-04 15:46:01
 ;;; Time-stamp: <2025-01-04 15:46:01 (ywatanabe)>

--- a/llemacs.el/llemacs.el
+++ b/llemacs.el/llemacs.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 ;;; -*- lexical-binding: t -*-
 ;;; Author: 2025-01-03 04:30:06
 ;;; Time-stamp: <2025-01-03 04:30:06 (ywatanabe)>

--- a/test.tex
+++ b/test.tex
@@ -1,0 +1,78 @@
+% Created 2025-01-03 Fri 12:49
+% Intended LaTeX compiler: pdflatex
+\documentclass[11pt]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{graphicx}
+\usepackage{longtable}
+\usepackage{wrapfig}
+\usepackage{rotating}
+\usepackage[normalem]{ulem}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{capt-of}
+\usepackage{hyperref}
+\author{Yusuke Watanabe}
+\date{2025-01-03 12:49:42}
+\title{Project Report: Trigonometric Functions Plot}
+\hypersetup{
+ pdfauthor={Yusuke Watanabe},
+ pdftitle={Project Report: Trigonometric Functions Plot},
+ pdfkeywords={},
+ pdfsubject={},
+ pdfcreator={Emacs 29.4 (Org mode 9.6.15)}, 
+ pdflang={English}}
+\begin{document}
+
+\maketitle
+\tableofcontents
+
+
+\section{Directory}
+\label{sec:org8a71917}
+/home/ywatanabe/proj/llemacs/workspace/projects/036-my-project/results
+
+\section{Python Script}
+\label{sec:orgd53ae16}
+\begin{verbatim}
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Create sample data
+x = np.linspace(0, 10, 1000)
+y1 = np.sin(x)
+y2 = np.cos(x)
+
+# Create plot
+plt.figure(figsize=(10, 6))
+plt.plot(x, y1, label='sin(x)', color='blue')
+plt.plot(x, y2, label='cos(x)', color='red')
+plt.xlabel('x')
+plt.ylabel('y')
+plt.title('Trigonometric Functions')
+plt.grid(True)
+plt.legend()
+
+# Save plot
+plt.savefig('results/figures/plot.jpg', bbox_inches='tight', dpi=300)
+plt.close()
+\end{verbatim}
+
+\section{Generated Plot}
+\label{sec:orge88dcc2}
+\begin{figure}[H]
+\centering
+\includegraphics[width=0.8\linewidth]{/home/ywatanabe/proj/llemacs/workspace/projects/036-my-project/results/figures/plot.jpg}
+\end{figure}
+
+\section{Description}
+\label{sec:org7195282}
+This plot shows the sine and cosine functions over the interval [0, 10].
+\begin{itemize}
+\item Blue line represents sin(x)
+\item Red line represents cos(x)
+\end{itemize}
+\end{document}

--- a/workspace/agents/agent-000/.emacs.d/init.el
+++ b/workspace/agents/agent-000/.emacs.d/init.el
@@ -1,3 +1,10 @@
+;; Copyright (C) 2024-2025 Yusuke Watanabe (ywatanabe@alumni.u-tokyo.ac.jp)
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
 (message "Hello world!")
 (insert "Hello world!")
 (switch-to-buffer "*Messages*")


### PR DESCRIPTION
- Introduced a GPL3 license and copyright headers.
- Restructured the Emacs Lisp codebase into modular directories.
- Added module entry points for each major feature.
- Incorporated a basic test suite for several modules.
- Removed and replaced old files, simplifying the directory structure.
- None
- This commit represents the initial project setup and does not include any functional changes beyond restructuring and license updates.